### PR TITLE
ON-2166 - OneModel Updates To Allow sklearn_adapter to Be Used With SHAP

### DIFF
--- a/lifelines/tests/utils/test_utils.py
+++ b/lifelines/tests/utils/test_utils.py
@@ -938,6 +938,14 @@ class TestSklearnAdapter:
         wf.fit(X, Y)
         assert wf.predict(X).shape[0] == X.shape[0]
 
+    def test_can_make_single_prediction(self, X, Y):
+
+        base_model = sklearn_adapter(CoxPHFitter, event_col="E")
+        cph = base_model()
+        cph.fit(X,Y)
+        cph.predict(X.iloc[0:1])
+
+
     def test_dill(self, X, Y):
         import dill
 

--- a/lifelines/utils/sklearn_adapter.py
+++ b/lifelines/utils/sklearn_adapter.py
@@ -73,8 +73,12 @@ class _SklearnModel(BaseEstimator, MetaEstimatorMixin, RegressorMixin):
         X: DataFrame or numpy array
 
         """
-        predictions = getattr(self.lifelines_model, self._predict_method)(X, **kwargs).squeeze().values
-        return predictions
+        predictions = getattr(self.lifelines_model, self._predict_method)(X, **kwargs)
+
+        if X.shape[0] > 1:
+            predictions = predictions.squeeze()
+
+        return predictions.values
 
     def score(self, X, y, **kwargs):
         """


### PR DESCRIPTION
**lifelines/utils/sklearn_adapter.py**
-  Fixes issue where, if a single row is passed to sklearn_adapter.predict, the squeeze() call will throw away most of the results and then cause an exception when .values is called against the remaining scalar value; update only calls squeeze on multi-row prediction and includes a test demonstrating the issue and its resolution